### PR TITLE
Update graalvm-ce image to 19.2.0.1 version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
-FROM oracle/graalvm-ce:1.0.0-rc16 as graalvm
+FROM oracle/graalvm-ce:19.2.0.1 as graalvm
 WORKDIR /work
 COPY ./target/micronaut-petclinic-*.jar .
+RUN gu install native-image
 RUN native-image --no-server -cp micronaut-petclinic-*.jar
 
 FROM frolvlad/alpine-glibc


### PR DESCRIPTION
Hi, 

I've tried to create a native image following README's instructions, `./mvnw package && docker build -t micronaut-petclinic .`, but I've got this error:

```
Step 4/9 : RUN native-image --no-server -cp micronaut-petclinic-*.jar
 ---> Running in 94706c3ba21a
Error: Please specify class containing the main entry point method. (see --help)
The command '/bin/sh -c native-image --no-server -cp micronaut-petclinic-*.jar' returned a non-zero code: 1
```

To solve it, in the Dockerfile I've updated graal-ce image version to the last one, 19.2.0.1. Additionally, I've got to add 'native-image' installation in the Dockerfile because it was extracted from the base GraalVM distribution. More information about this [here](https://github.com/oracle/docker-images/issues/1276).